### PR TITLE
Comment nodes no longer become 'dirty' when their position updates

### DIFF
--- a/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp
@@ -711,7 +711,7 @@ void SAutoSizeCommentNode::ResizeToFit()
 		// move to desired pos
 		if (!GetPosition().Equals(DesiredPos, .1f))
 		{
-			GraphNode->Modify();
+			//GraphNode->Modify();
 			GraphNode->NodePosX = DesiredPos.X;
 			GraphNode->NodePosY = DesiredPos.Y;
 		}


### PR DESCRIPTION
Previously, the comment nodes were becoming "dirty" (marking unsaved changes) frequently, so that even if you clicked "Save," the asterisk by the blueprint name would often show up right away, as if the blueprint still needed to be saved. Now the positional change of the comment nodes doesn't 'dirty' the asset.